### PR TITLE
Change "name" description to match the regex.

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -49,7 +49,7 @@ module.exports = function() {
 		properties: {
 			name: {
 				pattern: /^[a-zA-Z0-9\-]+$/,
-				description: 'Name (letters, spaces, and dashes)',
+				description: 'Name (letters, numbers, and dashes)',
 				required: true
 			},
 			hosts: {


### PR DESCRIPTION
The prompt says to use 'Name (letters, spaces, and dashes)', but spaces aren't recognized in the RegEx. This updates the docs to match what we really want - characters to generate the folder name (which is most often alphanumeric + dashes or underscores, minus the underscores here).
